### PR TITLE
fix(ci): push all tags

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -49,4 +49,4 @@ jobs:
           # docker create latest tag
           docker tag ${IMAGE}:${{ steps.dump-version.outputs.new_tag }} ${IMAGE}:latest
           # docker push images
-          docker push ${IMAGE}
+          docker push --all-tags ${IMAGE}


### PR DESCRIPTION
# Problem
On DockerHub, you can see that only the latest tag is pushed (https://hub.docker.com/r/steinbrueckri/envsubst/tags). The other tags are 5 years old. New tags are created in this repository, but the images related to that tag are never pushed. Only latest is pushed.

# Expected
Images related to the git tags are also pushed.

# Reasoning
In our company, we want to stay up-to-date with the latest images, but never run "latest" itself. If a pod restarts for whatever reason and it suddenly breaks, we cannot easily figure out what exact change caused it. By pinning the version, this should not happen.

We use a similar tool to dependabot (called Renovate), which also updates to the latest version. This repository is currently not usable, because only latest is pushed. Older tags were pushed, so I am not sure what changed.

# Analysis
The workflow has this command to push images:
```
docker push ${IMAGE}
```
If you look at the logging of any push action, you can clearly see it states that it only pushes latest:
```
Using default tag: latest
The push refers to repository [docker.io/steinbrueckri/envsubst]
dbe2aeedc982: Preparing
ab242de0bc0e: Preparing
871a501f7d60: Preparing
7bb20cf5ef67: Preparing
7bb20cf5ef67: Mounted from library/alpine
ab242de0bc0e: Pushed
dbe2aeedc982: Pushed
871a501f7d60: Pushed
latest: digest: sha256:0bd1f25fc0ca2a760ce5e386168685f37ff487ead8e810c55ef11224a5ba8850 size: 1152
```

This can be easily fixed with either adding `--all-tags` to the command or pushing the images separately:
```
docker push ${IMAGE}:latest
docker push ${IMAGE}:${{ steps.dump-version.outputs.new_tag }}
```

Adding the `--all-tags` seems like the easiest fix.

# Not tested
I have no way to actually test this. The argument is clearly documented (https://docs.docker.com/reference/cli/docker/image/push/) and I have used it myself before (though not in a github action). It would be good to monitor the first publish pipeline that triggers!
