### PR TITLE
feat(script): process files in subdirectories as well

### DIFF
--- a/envsubst-file.sh
+++ b/envsubst-file.sh
@@ -1,20 +1,22 @@
 #!/usr/bin/env sh
 set -e
 
-PROCESSED=false
 WORKDIR=/workdir
+OUTPUTDIR=/processed
 
-for i in $(ls $WORKDIR); do
-  echo "Processing $i ..."
-
-  envsubst < "$WORKDIR/$i" > "/processed/$i"
-  PROCESSED=true
-done
-
-ls /processed/
-
-if [ ! $PROCESSED = true ]
-then
-  echo 'No files processed'
+if ! find "$WORKDIR" -type f -print -quit | grep -q .; then
+  echo "No files to process"
   exit 1
 fi
+
+find "$WORKDIR" -type f | while read -r file; do
+  RELATIVE_PATH="${file#$WORKDIR/}"
+  OUTPUT_PATH="$OUTPUTDIR/$RELATIVE_PATH"
+
+  echo "Processing $RELATIVE_PATH"
+
+  mkdir -p "$(dirname "$OUTPUT_PATH")"
+  envsubst < "$file" > "$OUTPUT_PATH"
+done
+
+echo "All files have been processed"


### PR DESCRIPTION
# Problem
The existing script does not allow for any subdirectories. If you create one in the workdir, then you get this error:
```
Processing subdir ...
envsubst: error while reading "standard input": Is a directory
```

This pull request is to implement the feature that files in subdirectories are processed and put into the same relative path inside the processed directory.

# My change
I have rewritten the script entirely. I think it is more robust this way. I will outline my thoughts on the changes below, so you understand why I made certain changes.
* Using the `find` command, it is executed in a separate process. This means that changes to a variable like `PROCESSED` are not detected anymore. I can rewrite the find with `-exec`, but I find that quite ugly. I choose to replace this construction with an identical one: checking if there are no input files. If there are input files, we are surely going to process something.
* I removed the `ls /processed/`. In the setup at our company, we have a PVC with many more files on there. Listing all of them would be a lot of unnecessary logging. I do understand that the `ls` command shows you that the files are actually created, but if the file was not created the envsubst command would throw an error. And we have `set -e` in the script, so I see no need for this check.
* Added an additional echo to indicate the script is done. I think it is always nice to properly indicate in the logging when a container finished running.

# Not a breaking change
I choose not to make it a breaking change.

Situations where the workdir has a subdirectory will likely not exist, because I have tested that it throws an error in these cases. Assuming users have a working setup, it will not affect that setup. The logging messages are slightly different, but that shouldn't be breaking.

# Testing
I have tested the scenarios using the following command:
```
docker build . -t image:test
docker run --rm -v /workdir:/workdir -v $(pwd)/processed:/processed -e "VAR_1=A" -e "VAR_2=b" image:test
```

I tested and verified the following scenario's:
* An empty workdir ends the command with an error (echo $? returns 1)
* A workdir with some files with "VAR_1". These are correctly substituted and placed into the processed directory.
* A workdir with nested subdirectories (tested depth 1 and 2) with some files. These are correctly placed in the corresponding subdirectory of the processed directory.
* Existing files or subdirectory in the process directory (running the same command twice) throws no error. Files are correctly substituted and mkdir command does not throw an error (because of the `-p`).

Output of one of the runs:
```
Processing subdir1/test.txt
Processing test.txt
All files have been processed
```