### PR TITLE
fix(script): support k8s directory mount

### DIFF
--- a/envsubst-file.sh
+++ b/envsubst-file.sh
@@ -9,7 +9,7 @@ if ! find "$WORKDIR" -type f -print -quit | grep -q .; then
   exit 1
 fi
 
-find "$WORKDIR" -type f | while read -r file; do
+find -L "$WORKDIR" -name '..*' -prune -o -type f -print | while read -r file; do
   RELATIVE_PATH="${file#$WORKDIR/}"
   OUTPUT_PATH="$OUTPUTDIR/$RELATIVE_PATH"
 


### PR DESCRIPTION
This allows us to mount a `ConfigMap`, etc as a directory without explicitly listing each file with `subPath` like so:

```yaml
          volumeMounts:
            - name: config
              mountPath: /workdir
              readOnly: true
      volumes:
        - name: config
          configMap:
            name: conf.d
```

The issue was k8s mounts the file as a symlink to a symlink... and `find ... -type f` finds the file, but it's not in the desired path. I added `echo "$file -> $OUTPUT_PATH"` for this output:

```
Processing ..2026_06_03_21_35_19.1865253572/immich.yaml
/workdir/..2026_06_03_21_35_19.1865253572/immich.yaml -> /processed/..2026_06_03_21_35_19.1865253572/immich.yaml
All files have been processed
```

Shelling into the pod, we can see some fun symlinks:

```
$ ls -altr /workdir/
total 12
lrwxrwxrwx 1 root node   18 Jun  3 21:59 immich.yaml -> ..data/immich.yaml
lrwxrwxrwx 1 root node   30 Jun  3 21:59 ..data -> ..2026_06_03_21_59_26.44971278
drwxr-sr-x 2 root node 4096 Jun  3 21:59 ..2026_06_03_21_59_26.44971278
drwxrwsrwx 3 root node 4096 Jun  3 21:59 .
drwxr-xr-x 1 root root 4096 Jun  3 21:59 ..
```

---

- adding `-L` makes `find` follow symlinks and then treats the link as a file
- we want to find the hidden link and directory with `-name '..*'` and `-prune` them
- `-o -type f -print` prints the rest of the files. Since we treated the links as files with -L, the right file shows up in the results.
- we need `-print` now because... something

```
Processing immich.yaml
/workdir/immich.yaml -> /processed/immich.yaml
All files have been processed
```

This doesn't affect previous behavior. With this fix I used `subPath` (which doesn't have this symlink issue) and `envsubst` worked as expected.

I tested by mounting a configmap over `/envsubst-file.sh`.

---

This directory mount behavior is documented... somewhat:

https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/

On that page is this explanation:

> In the output, you can see that the labels and annotations files are in a temporary subdirectory: in this example, ..2982_06_02_21_47_53.299460680. In the /etc/podinfo directory, ..data is a symbolic link to the temporary subdirectory. Also in the /etc/podinfo directory, labels and annotations are symbolic links.

> Using symbolic links enables dynamic atomic refresh of the metadata; updates are written to a new temporary directory, and the ..data symlink is updated atomically using [rename(2)](http://man7.org/linux/man-pages/man2/rename.2.html).

The page doesn't seem relevant, but k8s does this to all [projected volumes](https://kubernetes.io/docs/concepts/storage/projected-volumes/)